### PR TITLE
Add class and subject system

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A simple grade management system built with Python 3, Flask and SQLite.
 - User registration and login with separate password storage
 - Teacher panel to upload grades for students
 - Student panel to view personal grades, total and average
+- Manage classes and subjects; teachers select them when adding grades
 - SQLite database stored in `data.db`
 
 ## Usage

--- a/templates/base.html
+++ b/templates/base.html
@@ -10,6 +10,7 @@
             <a href="{{ url_for('logout') }}">Logout</a>
             {% if session['role'] == 'teacher' %}
                 <a href="{{ url_for('teacher') }}">Teacher</a>
+                <a href="{{ url_for('manage') }}">Manage</a>
             {% else %}
                 <a href="{{ url_for('student') }}">Student</a>
             {% endif %}

--- a/templates/manage.html
+++ b/templates/manage.html
@@ -1,0 +1,26 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Manage Classes and Subjects</h2>
+<h3>Add Class</h3>
+<form method="post">
+    <input type="hidden" name="type" value="class">
+    Name: <input type="text" name="name" required>
+    <input type="submit" value="Add Class">
+</form>
+<ul>
+{% for c in classes %}
+<li>{{ c[1] }}</li>
+{% endfor %}
+</ul>
+<h3>Add Subject</h3>
+<form method="post">
+    <input type="hidden" name="type" value="subject">
+    Name: <input type="text" name="name" required>
+    <input type="submit" value="Add Subject">
+</form>
+<ul>
+{% for s in subjects %}
+<li>{{ s[1] }}</li>
+{% endfor %}
+</ul>
+{% endblock %}

--- a/templates/student.html
+++ b/templates/student.html
@@ -2,9 +2,9 @@
 {% block content %}
 <h2>Your Grades</h2>
 <table border="1">
-<tr><th>Subject</th><th>Score</th></tr>
+<tr><th>Subject</th><th>Class</th><th>Score</th></tr>
 {% for g in grades %}
-<tr><td>{{ g[0] }}</td><td>{{ g[1] }}</td></tr>
+<tr><td>{{ g[0] }}</td><td>{{ g[1] }}</td><td>{{ g[2] }}</td></tr>
 {% endfor %}
 </table>
 <p>Total: {{ total }}</p>

--- a/templates/teacher.html
+++ b/templates/teacher.html
@@ -8,8 +8,20 @@
         <option value="{{ s[0] }}">{{ s[1] }}</option>
         {% endfor %}
     </select><br>
-    Subject: <input type="text" name="subject" required><br>
+    Class:
+    <select name="class">
+        {% for c in classes %}
+        <option value="{{ c[0] }}">{{ c[1] }}</option>
+        {% endfor %}
+    </select><br>
+    Subject:
+    <select name="subject">
+        {% for sub in subjects %}
+        <option value="{{ sub[0] }}">{{ sub[1] }}</option>
+        {% endfor %}
+    </select><br>
     Score: <input type="number" name="score" step="0.01" required><br>
     <input type="submit" value="Add Grade">
 </form>
+<p><a href="{{ url_for('manage') }}">Manage Classes/Subjects</a></p>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add `classes` and `subjects` tables in database
- allow teachers to select class and subject when entering grades
- provide management page for classes and subjects
- display class and subject info in student view
- document new functionality in README

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6844631a6c58832284057a8476d7d247