### PR TITLE
Add admin role with ranking views

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ A simple grade management system built with Python 3, Flask and SQLite.
 - User registration and login with separate password storage
 - Teacher panel to upload grades for students
 - Student panel to view personal grades, total and average
-- Manage classes and subjects; teachers select them when adding grades
+- Admin panel to view rankings
+- Manage classes and subjects; teachers or admins can add them
+- Class and school ranking pages
 - SQLite database stored in `data.db`
 
 ## Usage

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -1,0 +1,10 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Admin Panel</h2>
+<ul>
+    {% for c in classes %}
+    <li><a href="{{ url_for('class_rank', class_id=c[0]) }}">{{ c[1] }} Ranking</a></li>
+    {% endfor %}
+</ul>
+<p><a href="{{ url_for('school_rank') }}">School Ranking</a></p>
+{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -11,6 +11,11 @@
             {% if session['role'] == 'teacher' %}
                 <a href="{{ url_for('teacher') }}">Teacher</a>
                 <a href="{{ url_for('manage') }}">Manage</a>
+                <a href="{{ url_for('school_rank') }}">Ranking</a>
+            {% elif session['role'] == 'admin' %}
+                <a href="{{ url_for('admin') }}">Admin</a>
+                <a href="{{ url_for('manage') }}">Manage</a>
+                <a href="{{ url_for('school_rank') }}">Ranking</a>
             {% else %}
                 <a href="{{ url_for('student') }}">Student</a>
             {% endif %}

--- a/templates/ranking.html
+++ b/templates/ranking.html
@@ -1,0 +1,10 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>{{ title }}</h2>
+<table border="1">
+<tr><th>Rank</th><th>Student</th><th>Total</th></tr>
+{% for r in ranks %}
+<tr><td>{{ loop.index }}</td><td>{{ r[0] }}</td><td>{{ r[1] }}</td></tr>
+{% endfor %}
+</table>
+{% endblock %}

--- a/templates/register.html
+++ b/templates/register.html
@@ -8,6 +8,7 @@
     <select name="role">
         <option value="student">Student</option>
         <option value="teacher">Teacher</option>
+        <option value="admin">Admin</option>
     </select><br>
     <input type="submit" value="Register">
 </form>


### PR DESCRIPTION
## Summary
- support a new `admin` role in registration and navigation
- allow admins to manage classes/subjects and view ranking pages
- implement class and school ranking endpoints
- document new features in README

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6844f91f7d9c8322a60dca0fa84178e7